### PR TITLE
Update the sql_exporter Github repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Ansible Role: Prometheus SQL Exporter ([lrk.prometheus-sql-exporter](https://gal
 ![Ansible](https://img.shields.io/badge/dynamic/json.svg?label=min_ansible_version&url=https%3A%2F%2Fgalaxy.ansible.com%2Fapi%2Fv1%2Froles%2F23765%2F&query=$.min_ansible_version)
 ![Ansible](https://img.shields.io/ansible/quality/23765)
 
-An Ansible Role that install [Prometheus](https://prometheus.io) [SQL Exporter](https://github.com/free/sql_exporter).
+An Ansible Role that install [Prometheus](https://prometheus.io) [SQL Exporter](https://github.com/burningalchemist/sql_exporter).
 
 
 Supported OSes
@@ -28,8 +28,8 @@ Available variables along with default values are listed below (see `defaults/ma
 
 prom_sexp_group: prometheus_sql_exporter
 prom_sexp_user: prometheus_sql_exporter
-# Prometheus SQL Exporter release version (see: https://github.com/free/sql_exporter/releases for available versions)
-prom_sexp_version: 0.4
+# Prometheus SQL Exporter release version (see: https://github.com/burningalchemist/sql_exporter/releases for available versions)
+prom_sexp_version: 0.10.0
 
 # Prometheus SQL Exporter installation path
 prom_sexp_path_install: /opt/prometheus/sql-exporter
@@ -40,15 +40,13 @@ prom_sexp_path_config: /etc/prometheus/sql-exporter
 # Prometheus SQL Exporter collectors path
 prom_sexp_path_collectors: "{{ prom_sexp_path_config }}/collectors"
 prom_sexp_path_collectors_suffix: ".collector.yml"
-# Prometheus SQL Exporter logs path
-prom_sexp_path_logs: "/var/log/prometheus/sql-exporter"
+# Prometheus SQL Exporter log level
+prom_sexp_log_level: DEBUG
 
 
 # Prometheus SQL Exporter service configuration
 # Service name prefix, the suffix is taken from target_name (see below)
 prom_sexp_service_name_prefix: prom-sql-exp
-# log to standard error as well as files (default true)
-prom_sexp_alsologtostderr: true
 
 # Array of Prometheus SQL Exporter targets
 # Each target:
@@ -176,7 +174,7 @@ Example Playbook
  ----------
 
 - [Prometheus.io](https://prometheus.io)
-- [Prometheus SQL Exporter](https://github.com/free/sql_exporter)
+- [Prometheus SQL Exporter](https://github.com/burningalchemist/sql_exporter)
 
 Author Information
 ------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,15 +15,12 @@ prom_sexp_path_config: /etc/prometheus/sql-exporter
 # Prometheus SQL Exporter collectors path
 prom_sexp_path_collectors: "{{ prom_sexp_path_config }}/collectors"
 prom_sexp_path_collectors_suffix: ".collector.yml"
-# Prometheus SQL Exporter logs path
-prom_sexp_path_logs: "/var/log/prometheus/sql-exporter"
-
+# Prometheus SQL Exporter log level
+prom_sexp_log_level: DEBUG
 
 # Prometheus SQL Exporter service configuration
 # Service name prefix, the suffix is taken from target_name (see below)
 prom_sexp_service_name_prefix: prom-sql-exp
-# log to standard error as well as files (default true)
-prom_sexp_alsologtostderr: true
 
 # Array of Prometheus SQL Exporter targets
 # Each target:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@
 prom_sexp_group: prometheus_sql_exporter
 prom_sexp_user: prometheus_sql_exporter
 # Prometheus SQL Exporter release version (see: https://github.com/free/sql_exporter/releases for available versions)
-prom_sexp_version: 0.4
+prom_sexp_version: 0.10.0
 
 # Prometheus SQL Exporter installation path
 prom_sexp_path_install: /opt/prometheus/sql-exporter

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,7 +24,6 @@
     mode: "u=rwx,g=rx,o="
   with_items:
     - "{{ prom_sexp_path_install }}"
-    - "{{ prom_sexp_path_logs }}"
     - "{{ prom_sexp_path_config }}"
     - "{{ prom_sexp_path_collectors }}"
 

--- a/templates/systemd_unit_file.service.j2
+++ b/templates/systemd_unit_file.service.j2
@@ -8,9 +8,8 @@ User={{ prom_sexp_user }}
 Restart=on-failure
 RestartSec=10
 ExecStart={{ prom_sexp_path_install }}/sql_exporter \
-          -alsologtostderr={{prom_sexp_alsologtostderr | default(true) | lower}} \
           -config.file={{ prom_sexp_target_config_file }} \
-          -log_dir={{ prom_sexp_path_logs }} \
+          -log.level={{ prom_sexp_log_level | lower }} \
           -web.listen-address={{ prom_sexp_target_listen_address }} \
           -web.metrics-path={{ prom_sexp_target_metrics_path }}
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,7 +3,7 @@
 
 # Internal vars, do not touch nor override
 __prom_sexp_tarball: "sql_exporter-{{ prom_sexp_version }}.linux-amd64.tar.gz"
-__prom_sexp_github_bin_url: "https://github.com/free/burningalchemist/releases/download/{{ prom_sexp_version }}/{{ __prom_sexp_tarball }}"
+__prom_sexp_github_bin_url: "https://github.com/burningalchemist/sql_exporter/releases/download/{{ prom_sexp_version }}/{{ __prom_sexp_tarball }}"
 __prom_sexp_default_listen_address: ":9399"
 __prom_sexp_default_metrics_path: "/metrics"
 __prom_sexp_default_scrape_timeout: 10s

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,7 +3,7 @@
 
 # Internal vars, do not touch nor override
 __prom_sexp_tarball: "sql_exporter-{{ prom_sexp_version }}.linux-amd64.tar.gz"
-__prom_sexp_github_bin_url: "https://github.com/free/sql_exporter/releases/download/{{ prom_sexp_version }}/{{ __prom_sexp_tarball }}"
+__prom_sexp_github_bin_url: "https://github.com/free/burningalchemist/releases/download/{{ prom_sexp_version }}/{{ __prom_sexp_tarball }}"
 __prom_sexp_default_listen_address: ":9399"
 __prom_sexp_default_metrics_path: "/metrics"
 __prom_sexp_default_scrape_timeout: 10s


### PR DESCRIPTION
Hello !

I'm currently using your Ansible role to deploy `sql_exporter` on some nodes (must say it works perfectly).

However, I've noticed that the Github repository currently used to pull the `sql_exporter` binary is [no longer maintained](https://github.com/free/sql_exporter/issues/119). There's [an active fork](https://github.com/burningalchemist/sql_exporter) still going though, so my PR suggests to swap these two repositories.

The general spirit stays the same, at the exception of two variables `prom_sexp_path_logs` and `prom_sexp_alsologtostderr` that are no longer used (no log file support for now).

Feel free to have a look and suggest other changes !